### PR TITLE
fix(snacks): prevent duplicate animation loops

### DIFF
--- a/lua/milli/init.lua
+++ b/lua/milli/init.lua
@@ -53,10 +53,15 @@ end
 -- User still seeds the header via `preset.header` - see README.
 function M.snacks(opts)
   opts = resolve(opts)
+  local playing = {}
   local function attach()
     local buf = vim.api.nvim_get_current_buf()
-    if vim.bo[buf].filetype == "snacks_dashboard" then
+    if vim.bo[buf].filetype == "snacks_dashboard" and not playing[buf] then
+      playing[buf] = true
       runtime.play(buf, opts)
+      vim.api.nvim_buf_attach(buf, false, {
+        on_detach = function() playing[buf] = nil end,
+      })
     end
   end
   vim.api.nvim_create_autocmd("User", {


### PR DESCRIPTION
**Bug**

`M.snacks()` registers listeners on both `SnacksDashboardOpened` and `SnacksDashboardUpdatePost`. Each event triggers a new `runtime.play()` loop on the same buffer with no deduplication — multiple loops race each other, sometimes causing a shaky animation.

**Fix**

Track currently-animating buffers in a `playing` table. If a buffer is already animating, skip starting a new loop. Clean up the entry via `nvim_buf_attach`'s `on_detach` callback when the dashboard buffer closes.
